### PR TITLE
`vdat_inspect()` patch-vr2ar-vrl

### DIFF
--- a/R/vdat_inspect.R
+++ b/R/vdat_inspect.R
@@ -32,6 +32,14 @@ vdat_inspect <- function(vdata_file, ...) {
     grepl("\\s{12,}", x = _) |>
     which()
 
+
+
+
+  ## Parse the metadata
+  ### Drop section headers by selecting rows that have a ":" or start with
+  ###   11 spaces then a character
+  metadata_1 <- metadata[grepl(":|^\\s{11}[[:alnum:]]", metadata)]
+
   ### Repeat those indices however many times to match the number of rows
   ###   in the section
   section_headers <- metadata[
@@ -45,12 +53,6 @@ vdat_inspect <- function(vdata_file, ...) {
   ] |>
     # Remove the spaces
     gsub("\\s", "", x = _)
-
-  ## Parse the metadata
-  ### Drop section headers by selecting rows that have a ":" or start with
-  ###   11 spaces then a character
-  metadata <- metadata[grepl(":|^\\s{11}[[:alnum:]]", metadata)]
-
   ### Split according to colons followed by multiple spaces.
   metadata <- metadata |>
     strsplit(":\\s+") |>

--- a/R/vdat_inspect.R
+++ b/R/vdat_inspect.R
@@ -40,15 +40,22 @@ vdat_inspect <- function(vdata_file, ...) {
   ###   11 spaces then a character
   metadata_1 <- metadata[grepl(":|^\\s{11}[[:alnum:]]", metadata)]
 
+  ### section headers need the parsed metadata
   ### Repeat those indices however many times to match the number of rows
-  ###   in the section
+  ### in the section
+  ### when reading in a vrl file the length of the section
+  ### headers becomes an issue so we have moved the location of this to happen
+  ### after the metadata has been parsed then
+  ### Because metadata_1 has the headers removed it will get the
+  ### spacing correct to sequience along as we do not
+  ### remove the  the headers, themselves which was in the orginal
+  ### You will also notice that we are first subseting metadata as it has
+  ### the section names in their index location which is first grabbed then
+  ### sequencing along at the length of metadata_1
   section_headers <- metadata[
     section_headers[
       # Repeat the headers however many times
-      findInterval(seq_along(metadata), vec = section_headers)[
-        # But not the headers, themselves
-        -section_headers
-      ]
+      findInterval(seq_along(metadata_1), vec = section_headers)
     ]
   ] |>
     # Remove the spaces

--- a/R/vdat_inspect.R
+++ b/R/vdat_inspect.R
@@ -61,7 +61,7 @@ vdat_inspect <- function(vdata_file, ...) {
     # Remove the spaces
     gsub("\\s", "", x = _)
   ### Split according to colons followed by multiple spaces.
-  metadata <- metadata |>
+  metadata_1 <- metadata_1 |>
     strsplit(":\\s+") |>
     ### Variables with multiple entries have those entries indented and split
     ###   into different lines. Split these into two columns according to a
@@ -84,17 +84,17 @@ vdat_inspect <- function(vdata_file, ...) {
     x[which(isnotblank)][cumsum(isnotblank)]
   }
 
-  metadata$X1 <- locf(metadata$X1)
+  metadata_1$X1 <- locf(metadata_1$X1)
 
   ### Add back section headers
-  metadata$section <- section_headers
+  metadata_1$section <- section_headers
 
   ### Remove redundant variables
-  metadata <- metadata[metadata$X1 != metadata$X2, ]
+  metadata_1 <- metadata_1[metadata_1$X1 != metadata_1$X2, ]
 
   ### Rename
-  names(metadata) <- c("variable", "value", "section")
+  names(metadata_1) <- c("variable", "value", "section")
 
 
-  invisible(metadata)
+  invisible(metadata_1)
 }

--- a/tests/testthat/test-vdat_inspect.R
+++ b/tests/testthat/test-vdat_inspect.R
@@ -13,6 +13,9 @@ test_that("vdat_inspect outputs to console", {
   )
 
   # VR2AR vrl
+  # use to error related to issue #18 -
+  # pr vdat_inspect-patch-vr2ar-vrl fixes
+  # BH - 20 - aug -2025
   expect_output(
     vdat_inspect(
       grep(
@@ -75,6 +78,9 @@ test_that("vdat_inspect invisibly returns a data frame", {
   expect_s3_class(hr, "data.frame")
 
   # VR2AR vrl
+  # use to error related to issue #18 -
+  # pr vdat_inspect-patch-vr2ar-vrl fixes
+  # BH - 20 - aug -2025
   vr2ar <- expect_invisible(
     vdat_inspect(
       grep(


### PR DESCRIPTION
This fixes #18 by changing the order of sequences. Below is the new order of opperations. 

1. `section_headers` is created as the index location of each header in `metadata`
2. `metadata` then has these section headers removed and this object is now called `metadata_1` - if you don't like this name we can change this easily. I know you were hoping to probably not create more than a few objects in this but I'm unsure how to to do this without creating a new object and referring back to the original. 
3. `section_headers` are then created based on their index location from `metadata` at the length of `metadata_1` using `seq_along()`.
4. After this point I have changed `metadata` to `metadata_1` so it returns the proper object. 

This clears tests for `vdat_inspect()` while there are other tests for other functions that do not clear but I am sure you're aware of those. Thank you for implementing `wine`. I can write up a workflow/vignette if you'd like on it and create another PR. 